### PR TITLE
fix: minor tweaks after chriswblake testrun

### DIFF
--- a/.github/steps/1-step.md
+++ b/.github/steps/1-step.md
@@ -39,7 +39,7 @@ Now let's configure [Azure DevOps](https://dev.azure.com/) credentials so we can
 1. Navigate to your [Azure DevOps](https://dev.azure.com/) organization in a new browser tab.
 1. Click on `User Settings` in top right corner, next to your profile picture.
 1. Select `Personal access tokens` from the dropdown menu. Click `New Token` to create a new personal access token.
-1. Give your token a descriptive name (e.g., `GitHub Skills Migration Exercise`).
+1. Give your token a descriptive name (e.g., `GitHub Skills Migration Exercise`) and set the expiration to a shorter duration (e.g., 1 day).
 1. Under `Scopes`, select `Custom defined` and choose the following scopes:
    - **Project and Team**: Read, write & manage (to create a project)
    - **Code**: Read, write & manage (to create repositories, branches, and files)

--- a/.github/steps/2-step.md
+++ b/.github/steps/2-step.md
@@ -75,11 +75,13 @@ The GitHub token provided in this codespace has limited scopes. For migration op
 
 1. Run the following command to grant the migrator role:
 
+   Replace `YOUR_ORG_NAME` with the GitHub organization name you want to migrate repositories to.
+
    ```bash
    gh ado2gh grant-migrator-role --actor {{ login }} --actor-type USER --github-org YOUR_ORG_NAME
    ```
 
-   Replace `YOUR_ORG_NAME` with the GitHub organization name you want to migrate repositories to.
+
 
 1. Verify the role was granted successfully by checking the command output.
 


### PR DESCRIPTION
This pull request updates the lab instructions to clarify steps and improve usability for users setting up Azure DevOps and GitHub credentials. The most important changes are grouped below:

Improvements to Azure DevOps setup instructions:

* Added direct links to [Azure DevOps](https://dev.azure.com/) in the instructions for easier navigation.
* Updated the guidance for creating a personal access token to recommend setting a shorter expiration (e.g., 1 day) for better security.

Clarifications to GitHub migration steps:

* Moved the instruction to replace `YOUR_ORG_NAME` to before the command block for better clarity and user experience.